### PR TITLE
Increase memory size for AMI public access lambda

### DIFF
--- a/deployment/cf-templates/identification.json
+++ b/deployment/cf-templates/identification.json
@@ -1085,7 +1085,7 @@
                                               ]},
                     "InitiateLambdaHandler": "initiate_to_desc_public_ami_issues.lambda_handler",
                     "EvaluateLambdaHandler": "describe_public_ami_issues.lambda_handler",
-                    "EvaluateLambdaMemorySize": 128,
+                    "EvaluateLambdaMemorySize": 256,
                     "LambdaLogsForwarderArn": { "Fn::GetAtt": ["LambdaLogsForwarder", "Arn"] },
                     "EventRuleDescription": "Hammer ScheduledRule to initiate public AMI access evaluations",
                     "EventRuleName": {"Fn::Join" : ["", [{ "Ref": "ResourcesPrefix" }, "InitiateEvaluationAMIPublicAccess"] ] },


### PR DESCRIPTION
This was previously set to 256 and was changed in latest commits.