### PR TITLE
Fix invalid JSON

### DIFF
--- a/deployment/cf-templates/identification-crossaccount-role.json
+++ b/deployment/cf-templates/identification-crossaccount-role.json
@@ -47,7 +47,7 @@
                                     "ec2:DescribeInstances",
                                     "ec2:DescribeRouteTables",
                                     "ec2:DescribeSubnets",
-                                    "ec2:DescribeImages",
+                                    "ec2:DescribeImages"
                                 ],
                                 "Resource": "*"
                             },


### PR DESCRIPTION
The invalid JSON causes terraform plan to fail, see issue #86