### PR TITLE
Update amiinfo lambda

### DIFF
--- a/hammer/identification/lambdas/ami-info/amiinfo.py
+++ b/hammer/identification/lambdas/ami-info/amiinfo.py
@@ -54,10 +54,11 @@ def lambda_handler(event, context):
             config=botocore.config.Config(retries={'max_attempts': 3})
         )
         images = ec2.describe_images(
-            Filters = [{
+            Filters=[{
                 "Name": "product-code",
                 "Values": [PRODUCT_CODE]
-            }]
+            }],
+            Owners=['aws-marketplace']
         )['Images']
     except Exception:
         logging.exception("Failed to describe images")


### PR DESCRIPTION
Set `Owners` parameter to `aws-marketplace`. This gets the latest official CentOS 7 image
instead of using latest CentOS 7 image accessible in the account that can be amended private
image. Using such an image can result in some undesirable side effects.